### PR TITLE
Set property for `dbDir` and patch `/tmp` collision issue in `scripts/install-javaparser.sh`

### DIFF
--- a/rv-monitor-rt/src/main/java/com/runtimeverification/rvmonitor/java/rt/util/TraceDB.java
+++ b/rv-monitor-rt/src/main/java/com/runtimeverification/rvmonitor/java/rt/util/TraceDB.java
@@ -25,12 +25,14 @@ public abstract class TraceDB {
 
     private String jdbcPassword = "";
     public TraceDB() {
+        updateDbDirProperty();
         this.connection = getConnection();
     }
 
     public TraceDB(String dbFilePath) {
         this.jdbcURL =  "jdbc:h2:" + dbFilePath + h2Options;
         setDbDir(dbFilePath);
+        updateDbDirProperty();
         this.connection = getConnection();
     }
 
@@ -145,5 +147,13 @@ public abstract class TraceDB {
 
     public void setDbDir(String dbDir) {
         this.dbDir = dbDir;
+    }
+
+    /**
+     * Update system properties to include dbDir information so that JUnit Listeners that work on the DB have access.
+     */
+    private void updateDbDirProperty() {
+        System.setProperty("dbFilePath", this.dbDir);
+        System.err.println("Set dbFilePath to: " + System.getProperty("dbFilePath"));
     }
 }

--- a/scripts/install-javaparser.sh
+++ b/scripts/install-javaparser.sh
@@ -1,5 +1,6 @@
 (
-    cd /tmp
+    mkdir -p javaparser-tmp
+    cd javaparser-tmp
     git clone https://github.com/javaparser/javaparser.git
     (
         cd javaparser
@@ -8,4 +9,5 @@
         rm javaparser-core/src/main/java/com/github/javaparser/ast/Node.java.bak
         mvn install -DskipTests -DskipITs
     )
+    rm -rf javaparser-tmp
 )


### PR DESCRIPTION
This PR contains two minor changes:

1. Changes to `TraceDB.java` update system properties to share the location of dbDir (the location of the database) so that JUnit listeners can locate and work on the database.
2. Changes to `scripts/install-javaparser.sh` patch a collision issue on `/tmp`. When two users run `install-javaparser.sh`, the  process for the second user fails because they do not have permission to create a new directory (which the compilation process attempts to do). To patch this issue, I've changed the location where javaparser will be cloned, and deleted that location to save some disk space.