### PR TITLE
Fix H2 Driver not found problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 *.rvm
 scripts/props/BaseAspect.aj
 scripts/props/classes/*
+scripts/props/*.aj
+scripts/props/*.rvm
 
 \#*\#
 .\#*

--- a/rv-monitor-rt/src/main/java/com/runtimeverification/rvmonitor/java/rt/util/AbstractH2TraceDB.java
+++ b/rv-monitor-rt/src/main/java/com/runtimeverification/rvmonitor/java/rt/util/AbstractH2TraceDB.java
@@ -78,9 +78,12 @@ public abstract class AbstractH2TraceDB implements TraceDB{
             return connection;
         }
         try {
+            Class.forName("org.h2.Driver");
             connection = DriverManager.getConnection(jdbcURL, jdbcUsername, jdbcPassword);
         } catch (SQLException e) {
             printSQLException(e);
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
         }
         return connection;
     }


### PR DESCRIPTION
The H2 Driver needs to be registered before a connection is made, otherwise an exception may be thrown.